### PR TITLE
Fix topic requests

### DIFF
--- a/dojot/module/auth.py
+++ b/dojot/module/auth.py
@@ -41,6 +41,28 @@ class Auth:
 
         return jwt
 
+    def get_access_token(self, tenant):
+        """
+        Retrieves a token for normal operations associated to a particular
+        tenant.
+
+        :rtype: str
+        :return: The token
+        """
+
+        userinfo = {
+            "username": self.config.dojot["management"]["user"],
+            "service": tenant
+        }
+
+        jwt = "{}.{}.{}".format(base64.b64encode("model".encode()).decode(),
+                                base64.b64encode(json.dumps(
+                                    userinfo).encode()).decode(),
+                                base64.b64encode("signature".encode()).decode())
+
+        return jwt
+
+
     def get_tenants(self):
         """
         Retrieves all tenants

--- a/dojot/module/kafka/topic_manager.py
+++ b/dojot/module/kafka/topic_manager.py
@@ -67,7 +67,7 @@ class TopicManager():
 
         url = self.broker + "/topic/" + subject + querystring
         ret = requests.get(url, headers={
-            'authorization': "Bearer " + self.auth.get_management_token()})
+            'authorization': "Bearer " + self.auth.get_access_token(tenant)})
         try:
             payload = ret.json()
         except ValueError as error:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -17,6 +17,20 @@ def test_get_management_token_ok():
     token = Auth.get_management_token(mockSelf)
     assert token is not None
 
+def test_get_access_token_ok():
+    config = Mock(
+        dojot={
+            "management": { 
+                "user" : "management-user", 
+                "tenant" : "non-management-tenant"
+            }
+        }
+    )
+    mockSelf = Mock(config=config)
+    token = Auth.get_access_token(mockSelf, "non-management-tenant")
+    assert token is not None
+
+
 def test_get_tenants_ok():
     config = Mock(
         auth={

--- a/tests/test_topic_manager.py
+++ b/tests/test_topic_manager.py
@@ -22,7 +22,7 @@ def test_get_key():
     assert ret == "sample-tenant:sample-subject"
 
 def test_get_topic_ok():
-    mockAuth = Mock(get_management_token=Mock(return_value="sample-token"))
+    mockAuth = Mock(get_access_token=Mock(return_value="sample-token"))
     patchResponse = patch("requests.Response.json", return_value={"topic": "sample-topic"})
     patchReqGet = patch("requests.get", return_value=requests.Response)
     with patchResponse, patchReqGet as mockReqGet:
@@ -31,10 +31,10 @@ def test_get_topic_ok():
         assert ret == "sample-topic"
         mockReqGet.assert_called_once_with("http://sample-broker/topic/sample-subject",
                                 headers={"authorization": "Bearer sample-token"})
-
+        mockAuth.get_access_token.assert_called_once_with("sample-tenant")
 
 def test_get_topic_global():
-    mockAuth = Mock(get_management_token=Mock(return_value="sample-token-global"))
+    mockAuth = Mock(get_access_token=Mock(return_value="sample-token-global"))
     patchResponse = patch("requests.Response.json", return_value={"topic": "sample-topic-global"})
     patchReqGet = patch("requests.get", return_value=requests.Response)
     with patchResponse, patchReqGet as mockReqGet:
@@ -43,9 +43,10 @@ def test_get_topic_global():
         assert ret == "sample-topic-global"
         mockReqGet.assert_called_once_with("http://sample-broker/topic/sample-subject-global?global=true",
                                 headers={"authorization": "Bearer sample-token-global"})
+        mockAuth.get_access_token.assert_called_once_with("sample-tenant")
 
 def test_get_topic_value_error():
-    mockAuth = Mock(get_management_token=Mock(return_value="sample-token-error"))
+    mockAuth = Mock(get_access_token=Mock(return_value="sample-token-error"))
     patchResponseJson = patch("requests.Response.json", side_effect=ValueError("nope"))
     patchReqGet = patch("requests.get", return_value=requests.Response)
     with patchResponseJson, patchReqGet as mockReqGet:
@@ -54,7 +55,7 @@ def test_get_topic_value_error():
         assert ret is None
         mockReqGet.assert_called_once_with("http://sample-broker/topic/sample-subject-error",
                                 headers={"authorization": "Bearer sample-token-error"})
- 
+        mockAuth.get_access_token.assert_called_once_with("sample-tenant")
 
 def test_get_topic_with_topic():
     mockSelf = Mock(get_key=TopicManager.get_key, topics={"sample-tenant:sample-subject": "sample-stored-value"})


### PR DESCRIPTION
This PR fixes a situation where common topics for subjects (such as "dojot.device-manager.device") would be retrieved using a management tenant. This would cause the component to use wrong topic, as it would not be related to the correct tenant ("admin", for instance).