### PR TITLE
Adding readthedocs config

### DIFF
--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -1,0 +1,6 @@
+build:
+  image: latest
+
+python:
+  version: 3.6
+  setup_py_install: true


### PR DESCRIPTION
As stated [here](https://blog.readthedocs.com/python-36-support/), readthedocs accepts a configuration file (beta for now), which allows python 3.6 to be used. As we use a few strings using f"{var}" format (which first appeared in python 3.6), we'll need to use that version.