### PR TITLE
Changing Kafka message reveival

### DIFF
--- a/dojot/module/auth.py
+++ b/dojot/module/auth.py
@@ -81,9 +81,11 @@ class Auth:
         while retry_counter > 0:
             try:
                 LOGGER.debug("Retrieving list of tenants from auth...")
+                LOGGER.debug(f"Remaining attempts: {retry_counter}")
                 ret = requests.get(
                     url, headers={'authorization': "Bearer " + self.get_management_token()})
 
+                LOGGER.debug(f"Got an answer from Auth.")
                 if ret.status_code is not 200:
                     LOGGER.warning(f"Auth returned a non-200 response")
                     LOGGER.warning(f"Code is {ret.status_code}.")
@@ -91,7 +93,7 @@ class Auth:
                 else:
                     payload = ret.json()
                     LOGGER.debug("... list of tenants retrieved from auth.")
-                
+
                 retry_counter = 0
             except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as connection_error:
                 LOGGER.warning(

--- a/dojot/module/config.py
+++ b/dojot/module/config.py
@@ -40,7 +40,8 @@ class Config:
                     },
                     "consumer": {
                         "group.id": "my-module",
-                        "metadata.broker.list": "kafka:9092"
+                        "metadata.broker.list": "kafka:9092",
+                        "poll_timeout": 2000
                     }
                 },
                 "data_broker" : {
@@ -70,12 +71,12 @@ class Config:
             }
 
         .. warning::
-        
+
             If set, the `dojot` section should be in sync with all other
             modules. Otherwise this module won't work properly.
 
         .. note::
-        
+
             The Kafka object is straight from librdkafka configuration,
             separated into producer and consumer subobjects. For more
             information about this configuration, you should check its
@@ -85,16 +86,22 @@ class Config:
         self.load_defaults()
         self.load_env()
         if config is not None:
-            if "kafka" in config: 
-                self.kafka = config["kafka"]
-            if "data_broker" in config: 
-                self.data_broker = config["data_broker"]
+            if "kafka" in config:
+                if "consumer" in config["kafka"]:
+                    self.kafka["consumer"] = {**self.kafka["consumer"] , **config["kafka"]["consumer"]}
+                if "producer" in config["kafka"]:
+                    self.kafka["producer"] = {**self.kafka["producer"] , **config["kafka"]["producer"]}
+            if "data_broker" in config:
+                self.data_broker = {**self.data_broker, **config["data_broker"]}
             if "device_manager" in config:
-                self.device_manager = config["device_manager"]
-            if "auth" in config: 
-                self.auth = config["auth"]
-            if "dojot" in config: 
-                self.dojot = config["dojot"]
+                self.device_manager = {**self.device_manager, **config["device_manager"]}
+            if "auth" in config:
+                self.auth = {**self.auth, **config["auth"]}
+            if "dojot" in config:
+                if "management" in config["dojot"]:
+                    self.dojot["management"] = {**self.dojot["management"], **config["dojot"]["management"]}
+                if "subjects" in config["dojot"]:
+                    self.dojot["subjects"] = {**self.dojot["subjects"], **config["dojot"]["subjects"]}
 
 
     def load_defaults(self):
@@ -118,6 +125,7 @@ class Config:
                 consumer:
                     group.id: "my-module"
                     metadata.broker.list: "kafka:9092"
+                    poll_timeout: 2000
             data_broker:
                 url: "http://data-broker"
             device_manager:
@@ -129,7 +137,7 @@ class Config:
                 timeout_sleep: 5
                 connection_retries: 3
             dojot:
-                management: 
+                management:
                     user: "dojot-management"
                     tenant: "dojot-management"
                 subjects:
@@ -137,15 +145,15 @@ class Config:
                     devices: "dojot.device-manager.device"
                     device_data: "device-data"
 
-        .. warning:: 
+        .. warning::
 
             Calling this function will overwrite any previously set
             configuration in the created object. Also setting any configuration
             *after* Kafka is started or any Messenger object is created will
             have no effect on them.
 
-        .. warning:: 
-        
+        .. warning::
+
             If set, the `dojot` section should be in sync with all other
             modules. Otherwise this module won't work properly.
 
@@ -165,7 +173,9 @@ class Config:
             },
             "consumer": {
                 "group.id": "my-module",
-                "metadata.broker.list": "kafka:9092"
+                "metadata.broker.list": "kafka:9092",
+                # particular to this library, not rd_kafka nor kafka itself
+                "poll_timeout": 2000
             }
         }
 
@@ -245,7 +255,7 @@ class Config:
 
         self.dojot["management"]["user"] = os.environ.get(
             'DOJOT_MANAGEMENT_USER', self.dojot["management"]["user"])
-    
+
         self.dojot["management"]["tenant"] = os.environ.get(
             'DOJOT_MANAGEMENT_TENANT', self.dojot["management"]["tenant"])
 

--- a/dojot/module/kafka/consumer.py
+++ b/dojot/module/kafka/consumer.py
@@ -29,12 +29,16 @@ class Consumer(threading.Thread):
         threading.Thread.__init__(self)
         self.topics = []
         self.broker = config.kafka['consumer']['metadata.broker.list'].split(',')
+        self.poll_timeout = config.kafka['consumer']['poll_timeout']
         self.group_id = group_id
         self.consumer = None
         self.callback = None
         LOGGER.info("Creating consumer on %s on group %s and topic %s",
                     self.broker, self.group_id, self.topics)
         self.consumer = KafkaConsumer(bootstrap_servers=self.broker, group_id=self.group_id)
+        self.should_stop = threading.Event()
+        self.should_reset_consumer = threading.Event()
+        self.topic_lock = threading.RLock()
         LOGGER.info("Consumer created %s", self.topics)
 
     def subscribe(self, topic, callback):
@@ -53,23 +57,41 @@ class Consumer(threading.Thread):
         with its results.
         """
 
+        LOGGER.info("Got a new topic to subscribe: %s", topic)
+        self.topic_lock.acquire()
+        self.topics.append(topic)
+        self.topic_lock.release()
+
+        self.callback = callback
+        self.should_reset_consumer.set()
+
+    def _reset_subscriptions(self):
+        self.topic_lock.acquire()
         try:
-            LOGGER.info("Got a new topic to subscribe: %s", topic)
             LOGGER.info("Current topic list: %s", self.topics)
-            self.topics.append(topic)
             self.consumer.subscribe(topics=self.topics)
             LOGGER.debug("Current subscriptions: %s", self.consumer.subscription())
-            LOGGER.info("Subscribed to topic %s", topic)
-            LOGGER.debug("Current topic list: %s", self.topics)
-            self.callback = callback
         except IllegalStateError as error:
             LOGGER.critical("Kafka is in illegal state: %s", error)
         except AssertionError as error:
-            LOGGER.critical("No topic was provided. Should be [%s]: %s", topic, error)
+            LOGGER.critical("No topic was provided.")
         except TypeError as error:
             LOGGER.critical("Kafka listener type is invalid: %s", error)
+        finally:
+            self.topic_lock.release()
+
+    def stop(self):
+        self.should_stop.set()
+
 
     def run(self):
         LOGGER.debug("Now running consumer for topics: %s", self.topics)
-        for msg in self.consumer:
-            self.callback(msg.topic, msg.value)
+        while self.should_stop.is_set() is False:
+            if self.should_reset_consumer.is_set():
+                self._reset_subscriptions()
+                self.should_reset_consumer.clear()
+
+            topics = self.consumer.poll(self.poll_timeout)
+            for topic in topics:
+                for msg in topics[topic]:
+                    self.callback(msg.topic, msg.value)

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with io.open('README.md', 'rt', encoding='utf8') as f:
 
 setup(
     name='dojot.module',
-    version='0.0.1a2',
+    version='0.0.1a3',
     url='http://github.com/dojot/dojot-module-python',
     project_urls=OrderedDict((
         ('Code', 'https://github.com/dojot/dojot-module-python.git'),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,6 +18,7 @@ def assert_kafka_config(config):
     assert "consumer" in config.kafka
     assert "group.id" in config.kafka["consumer"]
     assert "metadata.broker.list" in config.kafka["consumer"]
+    assert "poll_timeout" in config.kafka["consumer"]
 
 def assert_services_config(config):
     assert "url" in config.data_broker
@@ -64,7 +65,7 @@ def assert_extra_dojot_config(config):
 def test_default_config():
     config = assert_config_creation()
     assert_default_config(config)
-    
+
 def test_custom_config():
     kafka_data = {
         "kafka": {
@@ -91,9 +92,9 @@ def test_custom_config():
             "connection_retries": 3,
             "extra-auth": "data-auth"
         },
-        "device_manager": { 
-            "url": "http://device-manager:5000", 
-            "timeout_sleep": 5, 
+        "device_manager": {
+            "url": "http://device-manager:5000",
+            "timeout_sleep": 5,
             "connection_retries": 3,
             "extra-device-manager": "data-device-manager"
         }

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -7,7 +7,8 @@ def test_consumer_init_ok():
     with patch.object(KafkaConsumer, "__init__", return_value=None) as mockKafkaConsumer:
         config = Mock(kafka={
             "consumer": {
-                "metadata.broker.list": "k1,k2,k3"
+                "metadata.broker.list": "k1,k2,k3",
+                "poll_timeout": 1
             }
         })
         consumer = Consumer("sample-group-id", config, "sample-name")
@@ -21,17 +22,17 @@ def test_consumer_init_ok():
             bootstrap_servers=["k1", "k2", "k3"], group_id="sample-group-id")
 
 def test_consumer_subscribe_ok():
-    mockSelf = Mock(topics=[], 
+    mockSelf = Mock(topics=[],
             consumer = Mock(subscribe=MagicMock()),
             callback="")
     Consumer.subscribe(mockSelf, "sample-topic", "callback")
     assert mockSelf.topics == ["sample-topic"]
     assert mockSelf.callback == "callback"
-    mockSelf.consumer.subscribe.assert_called_with(topics=["sample-topic"])
+    mockSelf.consumer.subscribe.assert_not_called()
 
     mockSelf.consumer.subscribe = Mock(side_effect=IllegalStateError)
     Consumer.subscribe(mockSelf, "sample-topic-illegal", "callback-illegal")
-    
+
     mockSelf.consumer.subscribe = Mock(side_effect=AssertionError())
     Consumer.subscribe(mockSelf, "sample-topic-assertion", "callback-assertion")
 
@@ -42,8 +43,87 @@ def test_consumer_run_ok():
     msgA = Mock(topic="topic-a", value="value-a")
     msgB = Mock(topic="topic-b", value="value-b")
     msgC = Mock(topic="topic-c", value="value-c")
-    mockSelf = Mock(consumer=[msgA, msgB, msgC], callback=Mock())
+    mockSelf = Mock(
+        consumer=Mock(
+            poll=Mock(return_value=
+                {
+                    "topic-a": [msgA],
+                    "topic-b": [msgB],
+                    "topic-c": [msgC]
+                }),
+            callback=Mock()
+        ),
+        should_stop=Mock(is_set=Mock(side_effect=[False, True])),
+        should_reset_consumer=Mock(is_set=Mock(side_effect=[False])),
+        _reset_subscriptions=Mock()
+    )
+    def reset_scenario():
+        mockSelf.should_stop.is_set.reset_mock()
+        mockSelf.should_reset_consumer.is_set.reset_mock()
+        mockSelf._reset_subscriptions.reset_mock()
+
+    reset_scenario()
     Consumer.run(mockSelf)
     mockSelf.callback.assert_any_call("topic-c", "value-c")
     mockSelf.callback.assert_any_call("topic-b", "value-b")
     mockSelf.callback.assert_any_call("topic-a", "value-a")
+
+    reset_scenario()
+    mockSelf.should_stop.is_set.side_effect = [False, False, False, True]
+    mockSelf.should_reset_consumer.is_set.side_effect=[False, True, False]
+    Consumer.run(mockSelf)
+    mockSelf.callback.assert_any_call("topic-c", "value-c")
+    mockSelf.callback.assert_any_call("topic-b", "value-b")
+    mockSelf.callback.assert_any_call("topic-a", "value-a")
+    mockSelf._reset_subscriptions.assert_called_once()
+    mockSelf.should_reset_consumer.clear.assert_called_once()
+
+
+def test_consumer_reset_subscriptions():
+    mockSelf = Mock(
+        consumer=Mock(
+            subscribe=Mock(),
+            subscription=Mock(return_value="nope")
+        ),
+        topics=["sample-1"],
+        topic_lock=Mock(acquire=Mock(), release=Mock())
+    )
+    def reset_scenario():
+        mockSelf.consumer.subscribe.reset_mock()
+        mockSelf.topic_lock.acquire.reset_mock()
+        mockSelf.topic_lock.release.reset_mock()
+
+
+    def assert_function_called():
+        mockSelf.topic_lock.acquire.assert_called_once()
+        mockSelf.topic_lock.release.assert_called_once()
+        mockSelf.consumer.subscribe.assert_called_once_with(topics=["sample-1"])
+
+    reset_scenario()
+    Consumer._reset_subscriptions(mockSelf)
+    assert_function_called()
+
+    reset_scenario()
+    mockSelf.consumer.subscribe.side_effect=[IllegalStateError]
+    Consumer._reset_subscriptions(mockSelf)
+    assert_function_called()
+
+    reset_scenario()
+    mockSelf.consumer.subscribe.side_effect=AssertionError
+    Consumer._reset_subscriptions(mockSelf)
+    assert_function_called()
+
+    reset_scenario()
+    mockSelf.consumer.subscribe.side_effect=TypeError
+    Consumer._reset_subscriptions(mockSelf)
+    assert_function_called()
+
+
+def test_consumer_stop():
+    mockSelf = Mock(
+        should_stop=Mock(set=Mock())
+    )
+
+    Consumer.stop(mockSelf)
+    mockSelf.should_stop.set.assert_called_once()
+

--- a/tests/test_messenger.py
+++ b/tests/test_messenger.py
@@ -49,7 +49,7 @@ def test_messenger_init():
 
     def reset_scenario():
         mockMessengerProcess.reset_mock()
-    
+
     mockSelf = Mock(config=config, tenants=[], auth=Mock(get_tenants=Mock(return_value=["tenant1", "tenant2"])))
     with patchMessengerOn, patchMessengerProcess as mockMessengerProcess:
         mockSelf.process_new_tenant = mockMessengerProcess
@@ -75,12 +75,12 @@ def test_messenger_process_new_tenant():
             "tenant": "sample-management-tenant"
         }
     })
-    
+
     mockSelf = Mock(
-        tenants=[], 
-        subjects={}, 
-        config=config, 
-        _Messenger__bootstrap_tenants=Mock(), 
+        tenants=[],
+        subjects={},
+        config=config,
+        _Messenger__bootstrap_tenants=Mock(),
         emit=Mock())
 
     def reset_scenario():
@@ -91,8 +91,8 @@ def test_messenger_process_new_tenant():
 
     # Happy day route, no registered subjects
     reset_scenario()
-    Messenger.process_new_tenant(mockSelf, 
-        "sample-tenant", 
+    Messenger.process_new_tenant(mockSelf,
+        "sample-tenant",
         '{"tenant": "sample-tenant"}')
     mockSelf._Messenger__bootstrap_tenants.assert_not_called()
     mockSelf.emit.assert_called_once_with(
@@ -107,12 +107,12 @@ def test_messenger_process_new_tenant():
         "sample-subject": {
             "mode": "sample-subject-mode"
         }
-    }   
-    Messenger.process_new_tenant(mockSelf, 
-        "sample-tenant", 
+    }
+    Messenger.process_new_tenant(mockSelf,
+        "sample-tenant",
         '{"tenant": "sample-tenant"}')
     mockSelf._Messenger__bootstrap_tenants.assert_called_once_with("sample-subject",
-        "sample-tenant", 
+        "sample-tenant",
         "sample-subject-mode")
     mockSelf.emit.assert_called_once_with(
         "sample-tenancy-subject",
@@ -123,8 +123,8 @@ def test_messenger_process_new_tenant():
 
     # Invalid payload
     reset_scenario()
-    Messenger.process_new_tenant(mockSelf, 
-        "sample-tenant", 
+    Messenger.process_new_tenant(mockSelf,
+        "sample-tenant",
         'wrong-payload')
     mockSelf._Messenger__bootstrap_tenants.assert_not_called()
     mockSelf.emit.assert_not_called()
@@ -132,8 +132,8 @@ def test_messenger_process_new_tenant():
 
     # Missing tenant in data
     reset_scenario()
-    Messenger.process_new_tenant(mockSelf, 
-        "sample-tenant", 
+    Messenger.process_new_tenant(mockSelf,
+        "sample-tenant",
         '{"key" : "not-expected"}')
     mockSelf._Messenger_bootstrap_tenants.assert_not_called()
     mockSelf.emit.assert_not_called()
@@ -141,8 +141,8 @@ def test_messenger_process_new_tenant():
     # Tenant already bootstrapped
     reset_scenario()
     mockSelf.tenants = ["sample-tenant"]
-    Messenger.process_new_tenant(mockSelf, 
-        "sample-tenant", 
+    Messenger.process_new_tenant(mockSelf,
+        "sample-tenant",
         '{"tenant": "sample-tenant"}')
     mockSelf._Messenger__bootstrap_tenants.assert_not_called()
     mockSelf.emit.assert_not_called()
@@ -294,7 +294,7 @@ def test_messenger_process_kafka_messages():
     def reset_scenario():
         mockSelf.emit.reset_mock()
         mockSelf.topics={}
-    
+
     # Happy day
     mockSelf.topics = {
         "sample-topic": {
@@ -321,7 +321,7 @@ def test_messenger_publish():
     def reset_scenario():
         mockSelf.producer_topics={}
         mockSelf.producer.produce.reset_mock()
-    
+
     # Happy day
     mockSelf.producer_topics = {
         "sample-subject": {
@@ -381,16 +381,16 @@ def test_messenger_request_device():
 
     def reset_scenario():
         mockSelf.emit.reset_mock()
-    
+
     patchReqGet = patch("requests.get", return_value=mockResponse)
     patchSleep = patch("time.sleep")
-    
+
     with patchSleep, patchReqGet as mockReqRequest:
         Messenger.request_device(mockSelf, "sample-tenant")
         mockReqRequest.assert_called_with("http://sample-url/device", headers={
             'authorization': "Bearer super-secret-token"
         })
-        
+
         mockSelf.emit.assert_any_call("devices-subject", "sample-tenant", "message", "{\"event\": \"create\", \"data\": \"device-1\"}")
         mockSelf.emit.assert_any_call("devices-subject", "sample-tenant", "message", "{\"event\": \"create\", \"data\": \"device-2\"}")
 
@@ -398,13 +398,13 @@ def test_messenger_request_device():
 
     mockResponse.status_code = 301
     patchReqGet = patch("requests.get", return_value=mockResponse)
-     
+
     with patchSleep, patchReqGet as mockReqRequest:
         Messenger.request_device(mockSelf, "sample-tenant")
         mockReqRequest.assert_called_with("http://sample-url/device", headers={
             'authorization': "Bearer super-secret-token"
         })
-        
+
         mockSelf.emit.assert_not_called()
 
     reset_scenario()
@@ -428,7 +428,7 @@ def test_messenger_request_device():
         status_code=200
     )
     patchReqGet = patch("requests.get", side_effect=[mockResponse, mockResponse2])
-     
+
     with patchSleep, patchReqGet as mockReqRequest:
         Messenger.request_device(mockSelf, "sample-tenant")
         mockReqRequest.assert_any_call("http://sample-url/device", headers={
@@ -450,24 +450,24 @@ def test_messenger_request_device():
                 'authorization': "Bearer super-secret-token"
             })
             mockSelf.emit.assert_not_called()
-            
+
     reset_scenario()
     patchReqGet = patch("requests.get", side_effect=ConnectionError)
-    assert_exceptions(patchSleep, patchReqGet)   
+    assert_exceptions(patchSleep, patchReqGet)
 
     reset_scenario()
     patchReqGet = patch("requests.get", side_effect=Timeout)
-    assert_exceptions(patchSleep, patchReqGet)   
-        
+    assert_exceptions(patchSleep, patchReqGet)
+
     reset_scenario()
     patchReqGet = patch("requests.get", side_effect=TooManyRedirects)
     assert_exceptions(patchSleep, patchReqGet)
 
     reset_scenario()
     patchReqGet = patch("requests.get", side_effect=ValueError)
-    assert_exceptions(patchSleep, patchReqGet)   
+    assert_exceptions(patchSleep, patchReqGet)
 
-def test_messenger_generate_device_events(): 
+def test_messenger_generate_device_events():
     mockSelf = Mock(
         tenants=["tenant-1", "tenant-2"],
         request_device=Mock()
@@ -476,4 +476,13 @@ def test_messenger_generate_device_events():
     Messenger.generate_device_create_event_for_active_devices(mockSelf)
     mockSelf.request_device.assert_any_call("tenant-1")
     mockSelf.request_device.assert_any_call("tenant-2")
-    
+
+
+def test_messenger_shutdown():
+    mockSelf = Mock(
+        consumer=Mock(stop=Mock())
+    )
+
+    Messenger.shutdown(mockSelf)
+    mockSelf.consumer.stop.assert_called_once()
+


### PR DESCRIPTION
This PR changes a bit how messages are received from Kafka. Now it will use the `poll` method, so that it is possible to stop the thread gracefully (and therefore kill the process :smiling_imp:)

This is connected to dojot/dojot#824.