### PR TITLE
Fix: kafka, group id different for tenancy topics

### DIFF
--- a/dojot/module/config.py
+++ b/dojot/module/config.py
@@ -185,7 +185,7 @@ class Config:
                 "dr_cb": True
             },
             "consumer": {
-                "group_id": "my-module",
+                "group_id": "my-module-python-2",
                 "bootstrap_servers": ["kafka:9092"],
             },
             "dojot": {

--- a/dojot/module/config.py
+++ b/dojot/module/config.py
@@ -185,7 +185,7 @@ class Config:
                 "dr_cb": True
             },
             "consumer": {
-                "group_id": "my-module-python-2",
+                "group_id": "my-module-python",
                 "bootstrap_servers": ["kafka:9092"],
             },
             "dojot": {

--- a/dojot/module/config.py
+++ b/dojot/module/config.py
@@ -1,17 +1,17 @@
-"""
+'''
 Configuration data module
-"""
+'''
 
 import os
 
 class Config:
-    """
+    '''
     Main configuration class
 
     This class contains all needed configuration for this library
-    """
+    '''
     def __init__(self, config=None):
-        """
+        '''
         Config constructor
 
         :type config: dict or None
@@ -87,7 +87,7 @@ class Config:
             information about this configuration, you should check its
             documentation.
 
-        """
+        '''
         self.load_defaults()
         self.load_env()
         if config is not None:
@@ -112,7 +112,7 @@ class Config:
 
 
     def load_defaults(self):
-        """
+        '''
         Load default configuration, which is:
 
         .. code-block:: yaml
@@ -170,7 +170,7 @@ class Config:
             If set, the `dojot` section should be in sync with all other
             modules. Otherwise this module won't work properly.
 
-        """
+        '''
         self.kafka = {
             "producer": {
                 "client.id": "kafka",
@@ -225,7 +225,7 @@ class Config:
         }
 
     def load_env(self):
-        """
+        '''
         Load configuration from environment variables.
 
         Any environment variable will overwrite the default configuration.
@@ -254,7 +254,7 @@ class Config:
         - ``DOJOT_SUBJECT_DEVICE_DATA``: Subject to be used when asking
           DataBroker for device data topics.
 
-        """
+        '''
 
         bootstrap_servers = os.environ.get('KAFKA_HOSTS', None)
         if bootstrap_servers:

--- a/dojot/module/messenger.py
+++ b/dojot/module/messenger.py
@@ -6,6 +6,7 @@ import time
 import json
 import uuid
 import requests
+import copy  
 from .kafka import Producer
 from .kafka import TopicManager
 from .kafka import Consumer
@@ -97,7 +98,10 @@ class Messenger:
         # topics
         # These consumer MUST belong to a unique group because all consumer
         # SHOULD receive messages related to tenants.
-        self.consumer = Consumer(self.config, "dojot-module-"+ str(uuid.uuid4()))
+        groupID = "dojot-module-python-"+ str(uuid.uuid4())
+        configTenancy = copy.deepcopy(self.config)
+        configTenancy.kafka["consumer"]["group_id"] = groupID;
+        self.consumer = Consumer(configTenancy, groupID)
         LOGGER.debug("Creating consumer for tenancy messages...")
         self.create_channel(self.config.dojot['subjects']['tenancy'], "r", True)
         LOGGER.debug("... consumer for tenancy messages was successfully created.")

--- a/dojot/module/messenger.py
+++ b/dojot/module/messenger.py
@@ -100,7 +100,7 @@ class Messenger:
         # SHOULD receive messages related to tenants.
         groupID = "dojot-module-python-"+ str(uuid.uuid4())
         configTenancy = copy.deepcopy(self.config)
-        configTenancy.kafka["consumer"]["group_id"] = groupID;
+        configTenancy.kafka["consumer"]["group_id"] = groupID
         self.consumer = Consumer(configTenancy, groupID)
         LOGGER.debug("Creating consumer for tenancy messages...")
         self.create_channel(self.config.dojot['subjects']['tenancy'], "r", True)


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**
kafka should have group id different for tenancy topics


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)

dojot/dojot#1017

* **Other information**: