### PR TITLE
Keycloak as tenants owner

### DIFF
--- a/dojot/module/auth.py
+++ b/dojot/module/auth.py
@@ -36,7 +36,7 @@ class Auth:
         """
 
         url = self.config.keycloak['base_path'] + \
-            self.config.keycloak['token_endpoint']
+            'realms/master/protocol/openid-connect/token'
 
         form_params = self.config.keycloak['credentials']
 
@@ -82,8 +82,7 @@ class Auth:
         :return: List of tenants
         """
 
-        url = self.config.keycloak["base_path"] + \
-            self.config.keycloak['tenants_endpoint']
+        url = self.config.keycloak["base_path"] + 'admin/realms'
         retry_counter = self.config.keycloak["connection_retries"]
         timeout_sleep = self.config.keycloak["timeout_sleep"]
         try:

--- a/dojot/module/auth.py
+++ b/dojot/module/auth.py
@@ -11,10 +11,13 @@ from .http_requester import HttpRequester
 
 
 LOGGER = Log().color_log()
+
+
 class Auth:
     """
     Class responsible for authentication mechanisms in dojot
     """
+
     def __init__(self, config):
         """
         Object initialization
@@ -32,17 +35,20 @@ class Auth:
         :return: The token
         """
 
-        userinfo = {
-            "username": self.config.dojot["management"]["user"],
-            "service": self.config.dojot["management"]["tenant"]
-        }
+        url = self.config.keycloak['base_path'] + \
+            self.config.keycloak['token_endpoint']
 
-        jwt = "{}.{}.{}".format(base64.b64encode("model".encode()).decode(),
-                                base64.b64encode(json.dumps(
-                                    userinfo).encode()).decode(),
-                                base64.b64encode("signature".encode()).decode())
+        form_params = self.config.keycloak['credentials']
 
-        return jwt
+        try:
+            payload = requests.post(url, data=form_params)
+            token = payload.json()['access_token']
+        except Exception:
+            raise
+        else:
+            LOGGER.debug('token succefully generated')
+
+        return token
 
     def get_access_token(self, tenant):
         """
@@ -65,7 +71,6 @@ class Auth:
 
         return jwt
 
-
     def get_tenants(self):
         """
         Retrieves all tenants
@@ -77,10 +82,22 @@ class Auth:
         :return: List of tenants
         """
 
-        url = self.config.auth['url'] + "/admin/tenants"
-        retry_counter = self.config.auth["connection_retries"]
-        timeout_sleep = self.config.auth["timeout_sleep"]
-        payload = HttpRequester.do_it(url, self.get_management_token(), retry_counter, timeout_sleep)
+        url = self.config.keycloak["base_path"] + \
+            self.config.keycloak['tenants_endpoint']
+        retry_counter = self.config.keycloak["connection_retries"]
+        timeout_sleep = self.config.keycloak["timeout_sleep"]
+        try:
+            token = self.get_management_token()
+        except Exception:
+            LOGGER.debug('Unable generate token')
+            return None
+
+        payload = HttpRequester.do_it(
+            url, token, retry_counter, timeout_sleep)
         if payload is None:
-            return None # because Python, that's because.
-        return payload['tenants']
+            return None  # because Python, that's because.
+        else:
+            tenants = []
+            for tenant in payload:
+                tenants.append(tenant['realm'])
+            return tenants

--- a/dojot/module/config.py
+++ b/dojot/module/config.py
@@ -212,6 +212,20 @@ class Config:
             "connection_retries": 3
         }
 
+        self.keycloak = {
+            "timeout_sleep": 5,
+            "connection_retries": 3,
+            "base_path": "http://keycloak:8080/auth/",
+            "token_endpoint": "realms/master/protocol/openid-connect/token/",
+            "tenants_endpoint": "admin/realms/",
+            "credentials": {
+                "username": "admin",
+                "password": "admin",
+                "client_id": "admin-cli",
+                "grant_type": "password",
+            }
+        }
+
         self.dojot = {
             "management": {
                 "user" : "dojot-management",

--- a/dojot/module/config.py
+++ b/dojot/module/config.py
@@ -57,10 +57,16 @@ class Config:
                     "timeout_sleep": 5,
                     "connection_retries": 3
                 },
-                "auth" : {
-                    "url": "http://auth:5000",
+                "keycloak" = {
                     "timeout_sleep": 5,
-                    "connection_retries": 3
+                    "connection_retries": 3,
+                    "base_path": "http://keycloak:8080/auth/",
+                    "credentials": {
+                        "username": "admin",
+                        "password": "admin",
+                        "client_id": "admin-cli",
+                        "grant_type": "password",
+                    }
                 },
                 "dojot" : {
                     "management": {
@@ -145,10 +151,15 @@ class Config:
                 url: "http://device-manager:5000"
                 "timeout_sleep": 5
                 "connection_retries": 3
-            auth:
-                url: "http://auth:5000"
-                timeout_sleep: 5
-                connection_retries: 3
+            keycloak:
+                "base_path": "http://keycloak:8080/auth"
+                "timeout_sleep": 5
+                "connection_retries": 3
+                "credentials": 
+                    "username": "admin",
+                    "password": "admin",
+                    "client_id": "admin-cli",
+                    "grant_type": "password"
             dojot:
                 management:
                     user: "dojot-management"
@@ -216,8 +227,6 @@ class Config:
             "timeout_sleep": 5,
             "connection_retries": 3,
             "base_path": "http://keycloak:8080/auth/",
-            "token_endpoint": "realms/master/protocol/openid-connect/token/",
-            "tenants_endpoint": "admin/realms/",
             "credentials": {
                 "username": "admin",
                 "password": "admin",
@@ -257,6 +266,9 @@ class Config:
         - ``DATA_BROKER_URL``: Where DataBroker service can be reached.
         - ``DEVICE_MANAGER_URL``: URL to reach the device-manager service.
         - ``AUTH_URL``: Where Auth service can be reached.
+        - ``KEYCLOAK_URL``: Where Keycloak service can be reached.
+        - ``KEYCLOAK_USER``: Keycloak user (this user must have permission to list realms).
+        - ``KEYCLOAK_PASSWORD``: Keycloak user password.
         - ``DOJOT_MANAGEMENT_TENANT``: tenant to be used when asking
           DataBroker for management topics (such as tenancy-related topics)
         - ``DOJOT_MANAGEMENT_USER``: user to be used when asking
@@ -292,6 +304,10 @@ class Config:
             'DEVICE_MANAGER_URL', self.device_manager["url"])
 
         self.auth["url"] = os.environ.get('AUTH_URL', self.auth["url"])
+
+        self.keycloak["base_path"] = os.environ.get("KEYCLOAK_URL", self.keycloak["base_path"])
+        self.keycloak["credentials"]["username"] = os.environ.get("KEYCLOAK_USER", self.keycloak["credentials"]["username"])
+        self.keycloak["credentials"]["password"] = os.environ.get("KEYCLOAK_PASSWORD", self.keycloak["credentials"]["password"])
 
         self.dojot["management"]["user"] = os.environ.get(
             'DOJOT_MANAGEMENT_USER', self.dojot["management"]["user"])

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -3,26 +3,68 @@ import requests
 import unittest
 from unittest.mock import patch, MagicMock, Mock, DEFAULT
 from dojot.module import Auth, Config, HttpRequester
+import requests
+import json
+
 
 def test_get_management_token_ok():
     config = Mock(
-        dojot={
-            "management": {
-                "user" : "sample-user",
-                "tenant" : "sample-tenant"
+        keycloak={
+            "base_path": "http://kc_base_path/",
+            "token_endpoint": "kc_token_endpoint/",
+            "credentials": {
+                "username": "admin",
+                "password": "admin",
+                "client_id": "admin-cli",
+                "grant_type": "password",
             }
         }
     )
     mock_self = Mock(config=config)
-    token = Auth.get_management_token(mock_self)
-    assert token is not None
+
+    response = requests.Response()
+
+    def json_func():
+        return {"access_token": "xyz"}
+    response.json = json_func
+    patch_http_perform = patch(
+        "requests.post", return_value=response)
+    with patch_http_perform as mock_http_perform:
+        token = Auth.get_management_token(mock_self)
+        mock_http_perform.assert_called_with(
+            'http://kc_base_path/kc_token_endpoint/',
+            data=mock_self.config.keycloak['credentials'])
+        assert token == "xyz"
+
+def test_get_management_token_fail():
+    config = Mock(
+        keycloak={
+            "base_path": "http://kc_base_path/",
+            "token_endpoint": "kc_token_endpoint/",
+            "credentials": {
+                "username": "admin",
+                "password": "admin",
+                "client_id": "admin-cli",
+                "grant_type": "password",
+            }
+        }
+    )
+    
+    mock_self = Mock(config=config)
+
+    patch_http_perform = patch("requests.post")
+    with patch_http_perform as mock_http_perform:
+        mock_http_perform.side_effect = requests.exceptions.ConnectionError()
+        with pytest.raises(Exception):
+            Auth.get_management_token(mock_self)
+
 
 def test_get_access_token_ok():
     config = Mock(
         dojot={
             "management": {
-                "user" : "management-user",
-                "tenant" : "non-management-tenant"
+                "user": "management-user",
+                "tenant": "non-management-tenant"
             }
         }
     )
@@ -33,10 +75,17 @@ def test_get_access_token_ok():
 
 def test_get_tenants():
     config = Mock(
-        auth={
-            "url": "http://sample-url",
+        keycloak={
             "timeout_sleep": 1,
-            "connection_retries": 3
+            "connection_retries": 3,
+            "base_path": "http://kc_base_path/",
+            "tenants_endpoint": "keycloak_tenants_endpoint/",
+            "credentials": {
+                "username": "admin",
+                "password": "admin",
+                "client_id": "admin-cli",
+                "grant_type": "password",
+            }
         },
         dojot={
             "management": {
@@ -50,13 +99,47 @@ def test_get_tenants():
         config=config
     )
 
-    patch_http_perform = patch("dojot.module.HttpRequester.do_it", return_value={"tenants": "admin"})
+    master_tenant = '[{"realm": "master"}]'
+    patch_http_perform = patch(
+        "dojot.module.HttpRequester.do_it", return_value=json.loads(master_tenant))
     with patch_http_perform as mock_http_perform:
         tenants = Auth.get_tenants(mock_self)
-        mock_http_perform.assert_called_with("http://sample-url/admin/tenants", "123", 3, 1)
-        assert tenants == "admin"
-    patch_http_perform = patch("dojot.module.HttpRequester.do_it", return_value=None)
+        mock_http_perform.assert_called_with(
+            "http://kc_base_path/keycloak_tenants_endpoint/", "123", 3, 1)
+        assert tenants[0] == "master"
+    patch_http_perform = patch(
+        "dojot.module.HttpRequester.do_it", return_value=None)
     with patch_http_perform as mock_http_perform:
         tenants = Auth.get_tenants(mock_self)
-        mock_http_perform.assert_called_with("http://sample-url/admin/tenants", "123", 3, 1)
+        mock_http_perform.assert_called_with(
+            "http://kc_base_path/keycloak_tenants_endpoint/", "123", 3, 1)
         assert tenants is None
+
+def test_get_tenants_fail():
+    config = Mock(
+        keycloak={
+            "timeout_sleep": 1,
+            "connection_retries": 3,
+            "base_path": "http://kc_base_path/",
+            "tenants_endpoint": "keycloak_tenants_endpoint/",
+            "credentials": {
+                "username": "admin",
+                "password": "admin",
+                "client_id": "admin-cli",
+                "grant_type": "password",
+            }
+        },
+        dojot={
+            "management": {
+                "user": "sample-user",
+                "tenant": "sample-tenant"
+            }
+        }
+    )
+    mock_self = Mock(
+        get_management_token=Mock(side_effect=requests.exceptions.ConnectionError()),
+        config=config
+    )
+
+    tenants = Auth.get_tenants(mock_self)
+    assert tenants is None

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -11,7 +11,6 @@ def test_get_management_token_ok():
     config = Mock(
         keycloak={
             "base_path": "http://kc_base_path/",
-            "token_endpoint": "kc_token_endpoint/",
             "credentials": {
                 "username": "admin",
                 "password": "admin",
@@ -32,15 +31,15 @@ def test_get_management_token_ok():
     with patch_http_perform as mock_http_perform:
         token = Auth.get_management_token(mock_self)
         mock_http_perform.assert_called_with(
-            'http://kc_base_path/kc_token_endpoint/',
+            'http://kc_base_path/realms/master/protocol/openid-connect/token',
             data=mock_self.config.keycloak['credentials'])
         assert token == "xyz"
+
 
 def test_get_management_token_fail():
     config = Mock(
         keycloak={
             "base_path": "http://kc_base_path/",
-            "token_endpoint": "kc_token_endpoint/",
             "credentials": {
                 "username": "admin",
                 "password": "admin",
@@ -49,7 +48,7 @@ def test_get_management_token_fail():
             }
         }
     )
-    
+
     mock_self = Mock(config=config)
 
     patch_http_perform = patch("requests.post")
@@ -79,7 +78,6 @@ def test_get_tenants():
             "timeout_sleep": 1,
             "connection_retries": 3,
             "base_path": "http://kc_base_path/",
-            "tenants_endpoint": "keycloak_tenants_endpoint/",
             "credentials": {
                 "username": "admin",
                 "password": "admin",
@@ -105,15 +103,16 @@ def test_get_tenants():
     with patch_http_perform as mock_http_perform:
         tenants = Auth.get_tenants(mock_self)
         mock_http_perform.assert_called_with(
-            "http://kc_base_path/keycloak_tenants_endpoint/", "123", 3, 1)
+            "http://kc_base_path/admin/realms", "123", 3, 1)
         assert tenants[0] == "master"
     patch_http_perform = patch(
         "dojot.module.HttpRequester.do_it", return_value=None)
     with patch_http_perform as mock_http_perform:
         tenants = Auth.get_tenants(mock_self)
         mock_http_perform.assert_called_with(
-            "http://kc_base_path/keycloak_tenants_endpoint/", "123", 3, 1)
+            "http://kc_base_path/admin/realms", "123", 3, 1)
         assert tenants is None
+
 
 def test_get_tenants_fail():
     config = Mock(
@@ -137,7 +136,8 @@ def test_get_tenants_fail():
         }
     )
     mock_self = Mock(
-        get_management_token=Mock(side_effect=requests.exceptions.ConnectionError()),
+        get_management_token=Mock(
+            side_effect=requests.exceptions.ConnectionError()),
         config=config
     )
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -25,8 +25,6 @@ def assert_keycloak_config(config):
     assert "timeout_sleep" in config.keycloak
     assert "connection_retries" in config.keycloak
     assert "base_path" in config.keycloak
-    assert "token_endpoint" in config.keycloak
-    assert "tenants_endpoint" in config.keycloak
     assert "credentials" in config.keycloak
     assert "username" in config.keycloak['credentials']
     assert "password" in config.keycloak['credentials']
@@ -158,6 +156,9 @@ def test_env_config():
     os.environ['DATA_BROKER_URL'] = "http://local-data-broker"
     os.environ['DEVICE_MANAGER_URL'] = "http://local-device-manager"
     os.environ['AUTH_URL'] = "http://local-auth"
+    os.environ['KEYCLOAK_URL'] = "http://local-keycloak:8080/auth/"
+    os.environ['KEYCLOAK_USER'] = "sample-user"
+    os.environ['KEYCLOAK_PASSWORD'] = "sample-password"
     os.environ['DOJOT_MANAGEMENT_USER'] = "local-mgmt"
     os.environ['DOJOT_MANAGEMENT_TENANT'] = "local-tenant"
     os.environ['DOJOT_SUBJECT_TENANCY'] = "dojot.local.tenancy"
@@ -200,12 +201,10 @@ def test_env_config():
         "keycloak":{
             "timeout_sleep": 5,
             "connection_retries": 3,
-            "base_path": "http://keycloak:8080/auth/",
-            "token_endpoint": "realms/master/protocol/openid-connect/token/",
-            "tenants_endpoint": "admin/realms/",
+            "base_path": "http://local-keycloak:8080/auth/",
             "credentials": {
-                "username" : "admin",
-                "password": "admin",
+                "username" : "sample-user",
+                "password": "sample-password",
                 "client_id": "admin-cli",
                 "grant_type": "password",
             }
@@ -234,4 +233,4 @@ def test_env_config():
     assert config.device_manager == data["device_manager"]
     assert config.data_broker == data["data_broker"]
     assert config.dojot == data["dojot"]
-    assert config.keycloak == data['keycloak']
+    assert config.keycloak == data['keycloak'] 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,6 +21,18 @@ def assert_kafka_config(config):
     assert "bootstrap_servers" in config.kafka["consumer"]
     assert "poll_timeout" in config.kafka["dojot"]
 
+def assert_keycloak_config(config):
+    assert "timeout_sleep" in config.keycloak
+    assert "connection_retries" in config.keycloak
+    assert "base_path" in config.keycloak
+    assert "token_endpoint" in config.keycloak
+    assert "tenants_endpoint" in config.keycloak
+    assert "credentials" in config.keycloak
+    assert "username" in config.keycloak['credentials']
+    assert "password" in config.keycloak['credentials']
+    assert "client_id" in config.keycloak['credentials']
+    assert "grant_type" in config.keycloak['credentials']
+
 def assert_services_config(config):
     assert "url" in config.data_broker
     assert "timeout_sleep" in config.data_broker
@@ -44,6 +56,7 @@ def assert_dojot_config(config):
 
 def assert_default_config(config):
     assert_kafka_config(config)
+    assert_keycloak_config(config)
     assert_services_config(config)
     assert_dojot_config(config)
 
@@ -184,6 +197,19 @@ def test_env_config():
             "timeout_sleep": 5,
             "connection_retries": 3
         },
+        "keycloak":{
+            "timeout_sleep": 5,
+            "connection_retries": 3,
+            "base_path": "http://keycloak:8080/auth/",
+            "token_endpoint": "realms/master/protocol/openid-connect/token/",
+            "tenants_endpoint": "admin/realms/",
+            "credentials": {
+                "username" : "admin",
+                "password": "admin",
+                "client_id": "admin-cli",
+                "grant_type": "password",
+            }
+        },
         "device_manager": {
             "url": "http://local-device-manager",
             "timeout_sleep": 5,
@@ -208,3 +234,4 @@ def test_env_config():
     assert config.device_manager == data["device_manager"]
     assert config.data_broker == data["data_broker"]
     assert config.dojot == data["dojot"]
+    assert config.keycloak == data['keycloak']


### PR DESCRIPTION
Overview:
This PR change the tenants ownership from Auth to Keycloak, it implies retrieve tenants from Keycloak instead of Auth.

Please check if the PR fulfills these requirements:

- [ ] The added code are covered by unit tests
- [ ] The new implementation does not brake current library users
- [ ] The code agrees with PEP8 principles

What kind of change does this PR introduce? (Bug fix, feature, docs update, ...):
feature